### PR TITLE
Rendering stars like LGS did in software mode, but in OpenGL

### DIFF
--- a/src/GameSrc/frpipe.c
+++ b/src/GameSrc/frpipe.c
@@ -284,6 +284,10 @@ int fr_pipe_go_3(void) {
 
     //_fr_x_cen = fix_make(0, 2);
 
+    if (use_opengl()) {
+        opengl_draw_stars();
+    }
+
     int i, j, p_dir; // p_dir is how many per diagonal element
     uchar *loc_code_ptr, *quad_order;
     short clip_len[4]; // , clip_contrib[4];
@@ -295,10 +299,6 @@ int fr_pipe_go_3(void) {
     fr_rend_start();
     if ((_fr_curflags & FR_HACKCAM_MASK) == 0)
         do_seen_pass();
-
-    if (use_opengl()) {
-        opengl_draw_stars();
-    }
 
     // use clip len as temp for delta within the square
     clip_len[0] = (short)((fr_camera_last[0] & 0xffff) - 0x8000);

--- a/src/GameSrc/frpipe.c
+++ b/src/GameSrc/frpipe.c
@@ -284,10 +284,6 @@ int fr_pipe_go_3(void) {
 
     //_fr_x_cen = fix_make(0, 2);
 
-    if (use_opengl()) {
-        opengl_draw_stars();
-    }
-
     int i, j, p_dir; // p_dir is how many per diagonal element
     uchar *loc_code_ptr, *quad_order;
     short clip_len[4]; // , clip_contrib[4];
@@ -299,6 +295,10 @@ int fr_pipe_go_3(void) {
     fr_rend_start();
     if ((_fr_curflags & FR_HACKCAM_MASK) == 0)
         do_seen_pass();
+
+    if (use_opengl()) {
+        opengl_clear();
+    }
 
     // use clip len as temp for delta within the square
     clip_len[0] = (short)((fr_camera_last[0] & 0xffff) - 0x8000);

--- a/src/GameSrc/frsetup.c
+++ b/src/GameSrc/frsetup.c
@@ -820,11 +820,9 @@ int fr_send_view(void) {
     // rotation every 20 minutes, every 1 minute after explosion
     // with OpenGL, the starts have already been rendered before everything else
 
-    if (!use_opengl()) {
-        g3_start_object_angles_y(&zvec, QUESTBIT_GET(0x14) ? player_struct.game_time * 3 : player_struct.game_time / 5);
-        star_render();
-        g3_end_object();
-    }
+    g3_start_object_angles_y(&zvec, QUESTBIT_GET(0x14) ? player_struct.game_time * 3 : player_struct.game_time / 5);
+    star_render();
+    g3_end_object();
 
     g3_end_frame();
 

--- a/src/GameSrc/rendtool.c
+++ b/src/GameSrc/rendtool.c
@@ -78,7 +78,7 @@ LGRect *rendrect;
 extern fauxrend_context *_fr;
 ubyte mouselocked = 0;
 
-#define NUM_STARS 500
+#define NUM_STARS 1000
 
 sts_vec star_vec[NUM_STARS];
 uchar star_col[NUM_STARS];

--- a/src/GameSrc/star.c
+++ b/src/GameSrc/star.c
@@ -156,14 +156,16 @@ void star_poly(int n, g3s_phandle *vp) {
     g3s_phandle *p;
     int f;
 
-    // draw star poly in color zero.  This part very
-    // important, if not zero, won't work.
-    f = g3_draw_poly(0xff, n, vp);
-
     if(use_opengl()) {
+        // Stencil out this area where we want stars to draw
         opengl_set_stencil(0xFF);
-        opengl_draw_poly(0x00, n, vp, 0);
+        f = opengl_draw_poly(0x00, n, vp, 0);
         opengl_set_stencil(0x00);
+    }
+    else {
+        // draw star poly in color zero.  This part very
+        // important, if not zero, won't work.
+        f = g3_draw_poly(0xff, n, vp);
     }
 
     // snag points that have been fully clipped and projected

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -237,17 +237,8 @@ static void set_texture(grs_bitmap *bm) {
 }
 
 static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttrib) {
-
-    // Default, per-vertex lighting
-    float light = vertex.i / 4096.0f;
-
-    // Could be a CLUT color instead, use that for lighting
-    if(gr_get_fill_type() == FILL_CLUT) {
-        light = abs(((uchar)(gr_get_fill_parm() >> 4))) / 256.0f;
-    }
-
     glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);
-    glVertexAttrib1f(lightAttrib, 1.0f - light);
+    glVertexAttrib1f(lightAttrib, 1.0f - vertex.i / 4096.0f);
     glVertex3f(vertex.x / 65536.0f,  vertex.y / 65536.0f, -vertex.z / 65536.0f);
 }
 

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -25,6 +25,7 @@ extern "C" {
     #include "frflags.h"
     #include "player.h"
     #include "textmaps.h"
+    #include "star.h"
     #include "Shock.h"
 
     extern SDL_Renderer *renderer;
@@ -131,7 +132,9 @@ int init_opengl() {
 
     glEnable(GL_CULL_FACE);
     glEnable(GL_BLEND);
+    glEnable(GL_ALPHA_TEST);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glAlphaFunc(GL_GEQUAL, 0.001f);
 
     GLuint vertexShader = compileShader(GL_VERTEX_SHADER, VertexShader);
     GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, FragmentShader);
@@ -145,19 +148,10 @@ int init_opengl() {
     glGenTextures(1, &dynTexture);
     glGenTextures(1, &starsTexture);
 
-    const int stars_width = 1280;
-    const int stars_height = 400;
+    const int stars_width = 4;
+    const int stars_height = 4;
     uint8_t stars[stars_width * stars_height * 3];
     memset(stars, 0, sizeof(stars));
-    for (int i = 0; i < 500; ++i) {
-        int x = rand() % stars_width;
-        int y = rand() % stars_height;
-        int n = 3 * (y * stars_width + x);
-        uint8_t brightness = 128 + rand() % 128;
-        stars[n++] = brightness;
-        stars[n++] = brightness;
-        stars[n++] = brightness;
-    }
 
     glBindTexture(GL_TEXTURE_2D, starsTexture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, stars_width, stars_height, 0, GL_RGB, GL_UNSIGNED_BYTE, stars);
@@ -429,48 +423,69 @@ int opengl_draw_poly(long c, int n_verts, g3s_phandle *p, char gour_flag) {
     return CLIP_NONE;
 }
 
-void opengl_draw_stars() {
+void opengl_set_stencil(int v) {
+    glEnable(GL_STENCIL_TEST);
+    glStencilOp(GL_REPLACE, GL_REPLACE, GL_REPLACE);
+    glStencilFunc(GL_ALWAYS, v, ~0);
+}
+
+void opengl_begin_stars() {
     SDL_GL_MakeCurrent(window, context);
 
+    glPointSize(2.5f);
+    glEnable(GL_POINT_SMOOTH);
+
     GLint uniView = glGetUniformLocation(shaderProgram, "view");
-    glUniformMatrix4fv(uniView, 1, false, IdentityMatrix);
+    glUniformMatrix4fv(uniView, 1, false, ViewMatrix);
 
     GLint uniProj = glGetUniformLocation(shaderProgram, "proj");
-    glUniformMatrix4fv(uniProj, 1, false, IdentityMatrix);
+    glUniformMatrix4fv(uniProj, 1, false, ProjectionMatrix);
+
+    // Only draw stars where the stencil value is 0xFF (Sky!)
+    glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+    glStencilFunc(GL_EQUAL, 0xFF, ~0);
+}
+
+void opengl_end_stars() {
+    // Turn off the stencil test
+    opengl_set_stencil(0x00);
+}
+
+int opengl_draw_star(long c, int n_verts, g3s_phandle *p) {
+    SDL_GL_MakeCurrent(window, context);
 
     GLint tcAttrib = glGetAttribLocation(shaderProgram, "texcoords");
     GLint lightAttrib = glGetAttribLocation(shaderProgram, "light");
 
-    glBindTexture(GL_TEXTURE_2D, starsTexture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    g3s_point& vertex = *(p[0]);
+
+    set_color(200, 200, 200, 255);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, _blend_mode);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, _blend_mode);
+
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-    // see comment in fr_send_view(): rotation period is ~20 minutes before
-    // reactor blows, ~1.3 minutes after.
-    fixang angle = QUESTBIT_GET(0x14) ? player_struct.game_time * 3 : player_struct.game_time / 5;
-
-    extern g3s_angvec viewer_orientation;
-    float tc_top = -1.0 * viewer_orientation.tx / FIXANG_PI / 2;
-    float tc_bottom = tc_top + 0.5;
-    float tc_left = 1.0 * (viewer_orientation.ty - angle) / FIXANG_PI / 2;
-    float tc_right = tc_left + 0.25;
-
-    glBegin(GL_TRIANGLE_STRIP);
-    glVertexAttrib2f(tcAttrib, tc_right, tc_bottom);
+    // FIXME: Might be able to draw all the stars at once, in one Begin / End!
+    glBegin(GL_POINTS);
+    glVertexAttrib2f(tcAttrib, 0.1f, 0.1f);
     glVertexAttrib1f(lightAttrib, 1.0f);
-    glVertex3f(1.0f, -1.0f, 0.0f);
-    glVertexAttrib2f(tcAttrib, tc_right, tc_top);
-    glVertexAttrib1f(lightAttrib, 1.0f);
-    glVertex3f(1.0f, 1.0f, 0.0f);
-    glVertexAttrib2f(tcAttrib, tc_left, tc_bottom);
-    glVertexAttrib1f(lightAttrib, 1.0f);
-    glVertex3f(-1.0f, -1.0f, 0.0f);
-    glVertexAttrib2f(tcAttrib, tc_left, tc_top);
-    glVertexAttrib1f(lightAttrib, 1.0f);
-    glVertex3f(-1.0f, 1.0f, 0.0f);
+    glVertex3f(vertex.x / 65536.0f,  vertex.y / 65536.0f, -vertex.z / 65536.0f);
     glEnd();
+
+    return CLIP_NONE;
+}
+
+void opengl_draw_stars() {
+    SDL_GL_MakeCurrent(window, context);
+
+    // Make sure everything starts with a stencil of 0
+    glClearStencil(0x00);
+    glClear(GL_STENCIL_BUFFER_BIT);
+
+    // Draw everything with a stencil of 0
+    opengl_set_stencil(0x00);
 }
 
 #endif // USE_OPENGL

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -41,7 +41,6 @@ int _blend_mode = GL_LINEAR;
 static SDL_GLContext context;
 static GLuint shaderProgram;
 static GLuint dynTexture;
-static GLuint starsTexture;
 
 // static cache for the most important textures;
 // initialized during load_textures() in textmaps.c
@@ -134,7 +133,7 @@ int init_opengl() {
     glEnable(GL_BLEND);
     glEnable(GL_ALPHA_TEST);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glAlphaFunc(GL_GEQUAL, 0.001f);
+    glAlphaFunc(GL_GEQUAL, 0.05f);
 
     GLuint vertexShader = compileShader(GL_VERTEX_SHADER, VertexShader);
     GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, FragmentShader);
@@ -146,15 +145,6 @@ int init_opengl() {
 
     glGenTextures(NUM_LOADED_TEXTURES, textures);
     glGenTextures(1, &dynTexture);
-    glGenTextures(1, &starsTexture);
-
-    const int stars_width = 4;
-    const int stars_height = 4;
-    uint8_t stars[stars_width * stars_height * 3];
-    memset(stars, 0, sizeof(stars));
-
-    glBindTexture(GL_TEXTURE_2D, starsTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, stars_width, stars_height, 0, GL_RGB, GL_UNSIGNED_BYTE, stars);
 
     return 0;
 }
@@ -477,12 +467,12 @@ int opengl_draw_star(long c, int n_verts, g3s_phandle *p) {
     return CLIP_NONE;
 }
 
-void opengl_draw_stars() {
+void opengl_clear() {
     SDL_GL_MakeCurrent(window, context);
 
     // Make sure everything starts with a stencil of 0
-    glClearStencil(0x00);
-    glClear(GL_STENCIL_BUFFER_BIT);
+    glClearStencil(0xFF);
+    glClear(GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
 
     // Draw everything with a stencil of 0
     opengl_set_stencil(0x00);

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -253,8 +253,17 @@ static void set_texture(grs_bitmap *bm) {
 }
 
 static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttrib) {
+
+    // Default, per-vertex lighting
+    float light = vertex.i / 4096.0f;
+
+    // Could be a CLUT color instead, use that for lighting
+    if(gr_get_fill_type() == FILL_CLUT) {
+        light = ((uchar)(gr_get_fill_parm() >> 4)) / 256.0f;
+    }
+
     glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);
-    glVertexAttrib1f(lightAttrib, 1.0f - vertex.i / 4096.0f);
+    glVertexAttrib1f(lightAttrib, 1.0f - light);
     glVertex3f(vertex.x / 65536.0f,  vertex.y / 65536.0f, -vertex.z / 65536.0f);
 }
 

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -259,7 +259,7 @@ static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttr
 
     // Could be a CLUT color instead, use that for lighting
     if(gr_get_fill_type() == FILL_CLUT) {
-        light = ((uchar)(gr_get_fill_parm() >> 4)) / 256.0f;
+        light = abs(((uchar)(gr_get_fill_parm() >> 4))) / 256.0f;
     }
 
     glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);

--- a/src/MacSrc/OpenGL.h
+++ b/src/MacSrc/OpenGL.h
@@ -22,6 +22,10 @@ int opengl_light_tmap(int n, g3s_phandle *vp, grs_bitmap *bm);
 int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti);
 int opengl_draw_poly(long c, int n_verts, g3s_phandle *p, char gour_flag);
 void opengl_draw_stars();
+int opengl_draw_star(long c, int n_verts, g3s_phandle *p);
+void opengl_begin_stars();
+void opengl_end_stars();
+void opengl_set_stencil(int v);
 
 #else
 
@@ -38,6 +42,10 @@ static int opengl_light_tmap(int n, g3s_phandle *vp, grs_bitmap *bm) { return 0;
 static int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti) { return 0; }
 static int opengl_draw_poly(long c, int n_verts, g3s_phandle *p, char gour_flag) { return 0; }
 static void opengl_draw_stars() {}
+static int opengl_draw_star(long c, int n_verts, g3s_phandle *p) { return 0; }
+static void opengl_begin_stars() { }
+static void opengl_end_stars() { }
+static void opengl_set_stencil(int v);
 
 #endif
 

--- a/src/MacSrc/OpenGL.h
+++ b/src/MacSrc/OpenGL.h
@@ -21,7 +21,7 @@ int opengl_draw_tmap(int n, g3s_phandle *vp, grs_bitmap *bm);
 int opengl_light_tmap(int n, g3s_phandle *vp, grs_bitmap *bm);
 int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti);
 int opengl_draw_poly(long c, int n_verts, g3s_phandle *p, char gour_flag);
-void opengl_draw_stars();
+void opengl_clear();
 int opengl_draw_star(long c, int n_verts, g3s_phandle *p);
 void opengl_begin_stars();
 void opengl_end_stars();
@@ -41,7 +41,7 @@ static int opengl_draw_tmap(int n, g3s_phandle *vp, grs_bitmap *bm) { return 0; 
 static int opengl_light_tmap(int n, g3s_phandle *vp, grs_bitmap *bm) { return 0; }
 static int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti) { return 0; }
 static int opengl_draw_poly(long c, int n_verts, g3s_phandle *p, char gour_flag) { return 0; }
-static void opengl_draw_stars() {}
+static void opengl_clear() {}
 static int opengl_draw_star(long c, int n_verts, g3s_phandle *p) { return 0; }
 static void opengl_begin_stars() { }
 static void opengl_end_stars() { }


### PR DESCRIPTION
Stars were rendered in software mode before only in areas that were designated sky areas, we can do the same thing in OpenGL by using stencil testing.