### PR TITLE
Full texture cache with palette updating.

### DIFF
--- a/src/GameSrc/cybmem.c
+++ b/src/GameSrc/cybmem.c
@@ -40,6 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Shock.h"
 #include "sideicon.h"
 #include "criterr.h"
+#include "OpenGl.h"
 
 /*
 #include <memstat.h>
@@ -139,6 +140,8 @@ errtype load_dynamic_memory(int mask) {
 
         loadcount |= mask;
     }
+
+    opengl_clear_texture_cache();
 
     return (OK);
 }

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -292,9 +292,9 @@ void opengl_set_viewport(int x, int y, int width, int height) {
     glViewport(scaled_x, scaled_y, scaled_width, scaled_height);
 }
 
-bool opengl_cache_texture(CachedTexture toCache, grs_bitmap *bm) {
+static bool opengl_cache_texture(CachedTexture toCache, grs_bitmap *bm) {
     SDL_GL_MakeCurrent(window, context);
-    
+
     if(texturesByBitsPtr.size() < MAX_CACHED_TEXTURES) {
         // We have enough room, generate the new texture
         glGenTextures(1, &toCache.texture);
@@ -312,7 +312,7 @@ bool opengl_cache_texture(CachedTexture toCache, grs_bitmap *bm) {
     return false;
 }
 
-CachedTexture* opengl_get_texture(grs_bitmap *bm) {
+static CachedTexture* opengl_get_texture(grs_bitmap *bm) {
     std::map<uint8_t *, CachedTexture>::iterator iter = texturesByBitsPtr.find(bm->bits);
     if (iter != texturesByBitsPtr.end()) {
         return &iter->second;
@@ -476,11 +476,11 @@ int opengl_light_tmap(int n, g3s_phandle *vp, grs_bitmap *bm) {
     return CLIP_NONE;
 }
 
-float convx(float x) {
+static float convx(float x) {
     return  x/32768.0f / render_width - 1;
 }
 
-float convy(float y) {
+static float convy(float y) {
     return -y/32768.0f / render_height + 1;
 }
 
@@ -534,7 +534,7 @@ int opengl_bitmap(grs_bitmap *bm, int n, grs_vertex **vpl, grs_tmap_info *ti) {
     return CLIP_NONE;
 }
 
-void set_color(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha) {
+static void set_color(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha) {
     const uint8_t pixel[] = { red, green, blue, alpha };
     glBindTexture(GL_TEXTURE_2D, dynTexture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixel);

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -373,7 +373,9 @@ static void convert_texture(grs_bitmap *bm, bool locked) {
 
 void opengl_cache_texture(int idx, int size, grs_bitmap *bm) {
     if (idx < NUM_LOADED_TEXTURES) {
-        convert_texture(bm, true);
+        CachedTexture* t = opengl_get_texture(bm);
+        if(t == NULL)
+            convert_texture(bm, true);
     }
 }
 

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -253,8 +253,17 @@ static void set_texture(grs_bitmap *bm) {
 }
 
 static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttrib) {
+
+    // Default, per-vertex lighting
+    float light = vertex.i / 4096.0f;
+
+    // Could be a CLUT color instead, use that for lighting
+    if(gr_get_fill_type() == FILL_CLUT) {
+        light = ((uchar)(gr_get_fill_parm() >> 4)) / 256.0f;
+    }
+
     glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);
-    glVertexAttrib1f(lightAttrib, 1.0f - vertex.i / 4096.0f);
+    glVertexAttrib1f(lightAttrib, 1.0f - light);
     glVertex3f(vertex.x / 65536.0f,  vertex.y / 65536.0f, -vertex.z / 65536.0f);
 }
 

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -259,7 +259,8 @@ static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttr
 
     // Could be a CLUT color instead, use that for lighting
     if(gr_get_fill_type() == FILL_CLUT) {
-        light = abs(((uchar)(gr_get_fill_parm() >> 4))) / 256.0f;
+        int v = (gr_get_fill_parm() & 0x0F00) >> 4;
+        light = v / 256.0f;
     }
 
     glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -28,6 +28,7 @@ extern "C" {
     #include "textmaps.h"
     #include "star.h"
     #include "Shock.h"
+    #include "faketime.h"
 
     extern SDL_Renderer *renderer;
     extern SDL_Palette *sdlPalette;
@@ -37,6 +38,15 @@ extern "C" {
 #include <map>
 #include "frintern.h"
 
+struct CachedTexture {
+    SDL_Surface bitmap;
+    SDL_Surface converted;
+    GLuint texture;
+    long lastDrawTime;
+};
+
+#define MAX_CACHED_TEXTURES 1024
+
 bool _use_opengl = true;
 int _blend_mode = GL_LINEAR;
 
@@ -45,10 +55,8 @@ static GLuint shaderProgram;
 static GLuint dynTexture;
 static GLuint viewBackupTexture;
 
-// static cache for the most important textures;
-// initialized during load_textures() in textmaps.c
-static GLuint textures[NUM_LOADED_TEXTURES];
-static std::map<uint8_t *, GLuint> texturesByBitsPtr;
+// Texture cache to keep SDL surfaces and GL textures in memory
+static std::map<uint8_t *, CachedTexture> texturesByBitsPtr;
 
 static float view_scale;
 static int phys_width;
@@ -155,7 +163,6 @@ int init_opengl() {
     glLinkProgram(shaderProgram);
     glUseProgram(shaderProgram);
 
-    glGenTextures(NUM_LOADED_TEXTURES, textures);
     glGenTextures(1, &dynTexture);
     glGenTextures(1, &viewBackupTexture);
 
@@ -284,7 +291,52 @@ void opengl_set_viewport(int x, int y, int width, int height) {
     glViewport(scaled_x, scaled_y, scaled_width, scaled_height);
 }
 
-static void convert_texture(GLuint texture, grs_bitmap *bm) {
+bool opengl_cache_texture(CachedTexture toCache, grs_bitmap *bm) {
+    if(texturesByBitsPtr.size() < MAX_CACHED_TEXTURES) {
+        // We have enough room, generate the new texture
+        glGenTextures(1, &toCache.texture);
+        glBindTexture(GL_TEXTURE_2D, toCache.texture);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bm->w, bm->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, toCache.converted.pixels);
+
+        texturesByBitsPtr[bm->bits] = toCache;
+        return true;
+    }
+
+    // Not enough room, just use the dynTexture
+    glBindTexture(GL_TEXTURE_2D, dynTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bm->w, bm->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, toCache.converted.pixels);
+
+    return false;
+}
+
+CachedTexture* opengl_get_texture(grs_bitmap *bm) {
+    std::map<uint8_t *, CachedTexture>::iterator iter = texturesByBitsPtr.find(bm->bits);
+    if (iter != texturesByBitsPtr.end()) {
+        return &iter->second;
+    }
+    return NULL;
+}
+
+void opengl_clear_texture_cache() {
+    if(texturesByBitsPtr.size() == 0)
+        return;
+
+    DEBUG("Clearing OpenGL texture cache.");
+
+    std::map<uint8_t *, CachedTexture>::iterator iter;
+    for(iter = texturesByBitsPtr.begin(); iter != texturesByBitsPtr.end(); iter++) {
+        CachedTexture ct;
+        SDL_FreeSurface(&ct.bitmap);
+        SDL_FreeSurface(&ct.converted);
+        glDeleteTextures(1, &ct.texture);
+    }
+
+    texturesByBitsPtr.clear();
+}
+
+static void convert_texture(grs_bitmap *bm) {
+    SDL_GL_MakeCurrent(window, context);
+
     SDL_Surface *surface;
     if (bm->type == BMT_RSD8) {
         grs_bitmap decoded;
@@ -293,15 +345,23 @@ static void convert_texture(GLuint texture, grs_bitmap *bm) {
     } else {
         surface = SDL_CreateRGBSurfaceFrom(bm->bits, bm->w, bm->h, 8, bm->row, 0, 0, 0, 0);
     }
+
     SDL_SetSurfacePalette(surface, sdlPalette);
 
     SDL_Surface *rgba = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_RGBA32, 0);
 
-    glBindTexture(GL_TEXTURE_2D, texture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bm->w, bm->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba->pixels);
+    // Cache this new surface.
+    CachedTexture ct;
+    ct.bitmap = *surface;
+    ct.converted = *rgba;
+    ct.lastDrawTime = *tmd_ticks;
 
-    SDL_FreeSurface(rgba);
-    SDL_FreeSurface(surface);
+    bool cached = opengl_cache_texture(ct, bm);
+    if(!cached) {
+        DEBUG("Not enough room to cache texture!");
+        SDL_FreeSurface(surface);
+        SDL_FreeSurface(rgba);
+    }
 }
 
 void opengl_cache_texture(int idx, int size, grs_bitmap *bm) {
@@ -311,18 +371,37 @@ void opengl_cache_texture(int idx, int size, grs_bitmap *bm) {
         // only load the full-resolution into GL; use it in place of
         // down-scaled versions.
         if (size == TEXTURE_128_INDEX)
-            convert_texture(textures[idx], bm);
-        texturesByBitsPtr[bm->bits] = textures[idx];
+            convert_texture(bm);
     }
 }
 
 static void set_texture(grs_bitmap *bm) {
-    std::map<uint8_t *, GLuint>::iterator iter = texturesByBitsPtr.find(bm->bits);
-    if (iter != texturesByBitsPtr.end()) {
-        glBindTexture(GL_TEXTURE_2D, iter->second);
-    } else {
-        convert_texture(dynTexture, bm);
+    CachedTexture* t = opengl_get_texture(bm);
+    if(t == NULL) {
+        // Not cached, have to make it
+        convert_texture(bm);
+        return;
     }
+
+    // Only update the pixels once per frame.
+    if(t->lastDrawTime != *tmd_ticks) {
+        if (bm->type == BMT_RSD8) {
+            grs_bitmap decoded;
+            gr_rsd8_convert(bm, &decoded);
+            SDL_memmove(t->bitmap.pixels, decoded.bits, bm->w * bm->h);
+        }
+        else {
+            SDL_memmove(t->bitmap.pixels, bm->bits, bm->w * bm->h);
+        }
+
+        SDL_SetSurfacePalette(&t->bitmap, sdlPalette);
+        SDL_BlitSurface(&t->bitmap, NULL, &t->converted, NULL);
+
+        t->lastDrawTime = *tmd_ticks;
+    }
+
+    glBindTexture(GL_TEXTURE_2D, t->texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bm->w, bm->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, t->converted.pixels);
 }
 
 static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttrib) {
@@ -563,7 +642,7 @@ int opengl_draw_star(long c, int n_verts, g3s_phandle *p) {
 void opengl_clear() {
     SDL_GL_MakeCurrent(window, context);
 
-    // Make sure everything starts with a stencil of 0
+    // Make sure everything starts with a stencil of 0xFF
     glClearStencil(0xFF);
     glClear(GL_STENCIL_BUFFER_BIT);
 

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -390,24 +390,21 @@ static void set_texture(grs_bitmap *bm) {
         return;
     }
 
-    // Only update the pixels once per frame.
-    if(t->lastDrawTime != *tmd_ticks) {
-        if(!t->locked) {
-            if (bm->type == BMT_RSD8) {
-                grs_bitmap decoded;
-                gr_rsd8_convert(bm, &decoded);
-                SDL_memmove(t->bitmap->pixels, decoded.bits, bm->w * bm->h);
-            }
-            else {
-                SDL_memmove(t->bitmap->pixels, bm->bits, bm->w * bm->h);
-            }
+    if(!t->locked) {
+        if (bm->type == BMT_RSD8) {
+            grs_bitmap decoded;
+            gr_rsd8_convert(bm, &decoded);
+            SDL_memmove(t->bitmap->pixels, decoded.bits, bm->w * bm->h);
         }
-
-        SDL_SetSurfacePalette(t->bitmap, sdlPalette);
-        SDL_BlitSurface(t->bitmap, NULL, t->converted, NULL);
-
-        t->lastDrawTime = *tmd_ticks;
+        else {
+            SDL_memmove(t->bitmap->pixels, bm->bits, bm->w * bm->h);
+        }
     }
+
+    SDL_SetSurfacePalette(t->bitmap, sdlPalette);
+    SDL_BlitSurface(t->bitmap, NULL, t->converted, NULL);
+
+    t->lastDrawTime = *tmd_ticks;
 
     glBindTexture(GL_TEXTURE_2D, t->texture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bm->w, bm->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, t->converted->pixels);

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -259,7 +259,7 @@ static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttr
 
     // Could be a CLUT color instead, use that for lighting
     if(gr_get_fill_type() == FILL_CLUT) {
-        light = ((uchar)(gr_get_fill_parm() >> 4)) / 256.0f;
+        light = abs(((uchar)(gr_get_fill_parm() >> 4))) / 256.0f;
     }
 
     glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -33,6 +33,7 @@ extern "C" {
 }
 
 #include <map>
+#include "frintern.h"
 
 bool _use_opengl = true;
 int _blend_mode = GL_LINEAR;
@@ -259,8 +260,11 @@ static void draw_vertex(const g3s_point& vertex, GLint tcAttrib, GLint lightAttr
 
     // Could be a CLUT color instead, use that for lighting
     if(gr_get_fill_type() == FILL_CLUT) {
-        int v = (gr_get_fill_parm() & 0x0F00) >> 4;
-        light = v / 256.0f;
+        // Ugly hack: We don't get the original light value, so we have to
+        // recalculate it from the offset into the global lighting lookup
+        // table.
+        uchar* clut = (uchar*)gr_get_fill_parm();
+        light = (clut - grd_screen->ltab) / 4096.0f;
     }
 
     glVertexAttrib2f(tcAttrib, vertex.uv.u / 256.0, vertex.uv.v / 256.0);

--- a/src/MacSrc/OpenGL.h
+++ b/src/MacSrc/OpenGL.h
@@ -11,6 +11,7 @@ extern "C" {
 
 int init_opengl();
 void opengl_cache_texture(int idx, int size, grs_bitmap *bm);
+void opengl_clear_texture_cache();
 
 bool use_opengl();
 void toggle_opengl();
@@ -34,6 +35,7 @@ void opengl_set_stencil(int v);
 
 static int init_opengl() { return 0; }
 static void opengl_cache_texture(int idx, int size, grs_bitmap *bm) {}
+static void opengl_clear_texture_cache() {};
 
 static bool use_opengl() { return false; }
 static void toggle_opengl() {}

--- a/src/MacSrc/Shock.c
+++ b/src/MacSrc/Shock.c
@@ -316,10 +316,10 @@ void SDLDraw()
 {
 	SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, drawSurface);
 
-        if (should_opengl_swap()) {
+	if (should_opengl_swap()) {
 		opengl_backup_view();
 		SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
-        }
+	}
 
 	SDL_Rect srcRect = { 0, 0, gScreenWide, gScreenHigh };
 	SDL_RenderCopy(renderer, texture, &srcRect, NULL);


### PR DESCRIPTION
This implements a more fully featured texture cache for all bitmaps, not just walls. It also does an update-in-place of textures once per frame in case the palette changed so that palette animations work again.