### PR TITLE
Fix newlines in shader code files, just in case

### DIFF
--- a/build_windows.sh
+++ b/build_windows.sh
@@ -55,7 +55,7 @@ function get_cmake {
 }
 
 ## Actual building starts here
-
+dos2unix shaders/*.frag
 if [ -d ./build_ext/ ]; then
 	echo A directory named build_ext already exists.
 	echo Please remove it if you want to recompile.


### PR DESCRIPTION
Shader file compilation crashed on Windows, but forcing the newlines to Unix format saved the day. I'm adding some dos2unix magic to the bash script so it runs on Appveyor. The addition of GLEW forces a rebuild on local Windows builds as well, so this should be fine.