### PR TITLE
Better texture filtering of sprite edges

### DIFF
--- a/shaders/color.frag
+++ b/shaders/color.frag
@@ -7,9 +7,5 @@ uniform sampler2D tex;
 
 void main() {
     vec4 t = texture2D(tex, TexCoords);
-
-    // Throw away emissive part for now
-    float alpha = t.a > 0.5 ? 1.0 : t.a * 2.0;
-
-    gl_FragColor = vec4(t.r * Light, t.g * Light, t.b * Light, alpha);
+    gl_FragColor = vec4(t.r * Light, t.g * Light, t.b * Light, t.a);
 }

--- a/shaders/color.frag
+++ b/shaders/color.frag
@@ -7,5 +7,9 @@ uniform sampler2D tex;
 
 void main() {
     vec4 t = texture2D(tex, TexCoords);
-    gl_FragColor = vec4(t.r * Light, t.g * Light, t.b * Light, t.a);
+
+    // Throw away emissive part for now
+    float alpha = t.a > 0.5 ? 1.0 : t.a * 2.0;
+
+    gl_FragColor = vec4(t.r * Light, t.g * Light, t.b * Light, alpha);
 }

--- a/shaders/texture.frag
+++ b/shaders/texture.frag
@@ -12,7 +12,11 @@ uniform sampler2D tex;
 
 void main() {
     vec4 t = texture2D(tex, TexCoords);
-    float light = max(Light, t.a);
-    float alpha = t.a < 0.0001 ? 0.0 : 1.0;
+
+    // Alpha values > 0.5 are emissive
+    float alpha = t.a > 0.5 ? 1.0 : t.a * 2.0;
+    float emissive = t.a > 0.5 ? 1.0 : 0.0;
+    float light = max(Light, emissive);
+
     gl_FragColor = vec4(t.r * light, t.g * light, t.b * light, alpha);
 }

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -355,10 +355,11 @@ static SDL_Palette *createPalette(bool transparent) {
     for (int i = 1; i < 256; i++) {
         // colors 1..31, except 2: always at maximum light level
         // colors 2, 32..255: no minimum brightness, use interpolated vertex light level
+        // encode emissive property in the top half of the alpha color, since we don't use those bytes
         if (i < 32 && i != 2)
             palette->colors[i].a = 0xff;
         else
-            palette->colors[i].a = 0x01;
+            palette->colors[i].a = 0x7f;
     }
 
     return palette;


### PR DESCRIPTION
Forcing the alpha to be 0.0 or 1.0 in the texture shader made hard edges on sprites when they were filtered making odd outlines, this PR uses a better method of encoding the emissive property that lets texture filtering properly apply to alpha values.

The way this works is by encoding the emissive property in the top half of alpha values, and translucency in the bottom half.