### PR TITLE
3D view renders to a Framebuffer

### DIFF
--- a/src/GameSrc/frsetup.c
+++ b/src/GameSrc/frsetup.c
@@ -646,6 +646,10 @@ int fr_start_view(void) {
     uchar old_cam_type;
     int detail;
 
+    if(should_opengl_swap()) {
+        opengl_start_frame();
+    }
+
     // check detail for canvas sizing
     gr_set_canvas(&_fr->draw_canvas);
     if (_fr_curflags & FR_PICKUPM_MASK) {
@@ -829,7 +833,7 @@ int fr_send_view(void) {
     g3_end_frame();
 
     if(should_opengl_swap()) {
-        opengl_backup_view();
+        opengl_end_frame();
     }
 
     // stereo support - closedown ??

--- a/src/GameSrc/textmaps.c
+++ b/src/GameSrc/textmaps.c
@@ -252,7 +252,7 @@ void load_textures(void) {
                     //                              gr_bitmap(cur_bm, 0, 0);
                     //               });
                 }
-                opengl_cache_texture(c, n, cur_bm);
+                opengl_cache_wall_texture(c, n, cur_bm);
             }
             AdvanceProgress();
         }

--- a/src/Libraries/2D/Source/MacDev.c
+++ b/src/Libraries/2D/Source/MacDev.c
@@ -93,11 +93,13 @@ void mac_set_mode(void)
 
  void ChangeScreenSize(int width, int height)
  {
+    extern SDL_Renderer* renderer;
     extern SDL_Window* window;
+
+    SDL_RenderClear(renderer);
+    
     SDL_SetWindowSize(window, width, height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-
-    extern SDL_Renderer* renderer;
     SDL_RenderSetLogicalSize(renderer, width, height);
 
     extern short gScreenWide, gScreenHigh, gActiveWide, gActiveHigh;

--- a/src/MacSrc/OpenGL.cc
+++ b/src/MacSrc/OpenGL.cc
@@ -58,14 +58,23 @@ struct Shader {
     GLint lightAttrib;
 };
 
+struct FrameBuffer {
+    GLuint frameBuffer;
+    GLuint stencilBuffer;
+    GLuint texture;
+    int width;
+    int height;
+};
+
 #define MAX_CACHED_TEXTURES 1024
 
 static Shader textureShaderProgram;
 static Shader colorShaderProgram;
 
+static FrameBuffer backupBuffer;
+
 static SDL_GLContext context;
 static GLuint dynTexture;
-static GLuint viewBackupTexture;
 
 // Texture cache to keep SDL surfaces and GL textures in memory
 static std::map<uint8_t *, CachedTexture> texturesByBitsPtr;
@@ -108,6 +117,27 @@ static const float IdentityMatrix[] = {
     0.0, 0.0, 1.0, 0.0,
     0.0, 0.0, 0.0, 1.0
 };
+
+static void set_blend_mode(bool enabled) {
+    // change the blend mode, if not set already
+    if(blend_enabled != enabled) {
+        blend_enabled = enabled;
+        if(blend_enabled) {
+            glEnable(GL_BLEND);
+        }
+        else {
+            glDisable(GL_BLEND);
+        }
+    }
+}
+
+static void bind_texture(GLuint tex) {
+    // bind a texture, if not bound already
+    if(bound_texture != tex) {
+        bound_texture = tex;
+        glBindTexture(GL_TEXTURE_2D, bound_texture);
+    }
+}
 
 static GLuint compileShader(GLenum type, const char *source) {
     GLuint shader = glCreateShader(type);
@@ -175,6 +205,48 @@ static Shader CreateShader(const char *vertexShaderFile, const char *fragmentSha
     return cachedShader;
 }
 
+static FrameBuffer CreateFrameBuffer(int width, int height) {
+    FrameBuffer newBuffer;
+    newBuffer.width = width;
+    newBuffer.height = height;
+
+    // Make a frame buffer, texture for color, and render buffer for stencil
+    glGenFramebuffers(1, &newBuffer.frameBuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, newBuffer.frameBuffer);
+
+    glGenRenderbuffers(1, &newBuffer.stencilBuffer);
+    glBindRenderbuffer(GL_RENDERBUFFER, newBuffer.stencilBuffer);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_STENCIL_INDEX8, width, height);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, newBuffer.stencilBuffer);
+
+    glGenTextures(1, &newBuffer.texture);
+    glBindTexture(GL_TEXTURE_2D, newBuffer.texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, newBuffer.texture, 0);
+
+    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if(status != GL_FRAMEBUFFER_COMPLETE) {
+        ERROR("Could not make FrameBuffer!: %x \n", status);
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+    return newBuffer;
+}
+
+static void BindFrameBuffer(FrameBuffer *buffer) {
+    if(buffer == NULL) {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    }
+    else {
+        glBindFramebuffer(GL_FRAMEBUFFER, buffer->frameBuffer);
+        glBindRenderbuffer(GL_RENDERBUFFER, buffer->stencilBuffer);
+        glViewport(0, 0, buffer->width, buffer->height);
+    }
+}
+
 int init_opengl() {
     DEBUG("Initializing OpenGL");
     context = SDL_GL_CreateContext(window);
@@ -194,32 +266,12 @@ int init_opengl() {
     colorShaderProgram = CreateShader("main.vert", "color.frag");
 
     glGenTextures(1, &dynTexture);
-    glGenTextures(1, &viewBackupTexture);
 
     int width, height;
     SDL_GetWindowSize(window, &width, &height);
     opengl_resize(width, height);
 
     return 0;
-}
-
-static void set_blend_mode(bool enabled) {
-    if(blend_enabled != enabled) {
-        blend_enabled = enabled;
-        if(blend_enabled) {
-            glEnable(GL_BLEND);
-        }
-        else {
-            glDisable(GL_BLEND);
-        }
-    }
-}
-
-static void bind_texture(GLuint tex) {
-    if(bound_texture != tex) {
-        bound_texture = tex;
-        glBindTexture(GL_TEXTURE_2D, bound_texture);
-    }
 }
 
 void opengl_resize(int width, int height) {
@@ -247,13 +299,11 @@ void opengl_resize(int width, int height) {
     phys_offset_x = border_x / 2;
     phys_offset_y = border_y / 2;
 
-    // allocate a buffer for the framebuffer backup
-    bind_texture(viewBackupTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, phys_width, phys_height, 0, GL_RGB, GL_UNSIGNED_BYTE, 0);
+    backupBuffer = CreateFrameBuffer(logical_width, logical_height);
 
     INFO("OpenGL Resize %i %i %i %i", width, height, phys_width, phys_height);
 
-    // Redraw the background in the new resolution
+    // Redraw the options menu background in the new resolution
     extern uchar wrapper_screenmode_hack;
     if(wrapper_screenmode_hack) {
         render_run();
@@ -278,17 +328,26 @@ bool should_opengl_swap() {
            !global_fullmap->cyber;
 }
 
-void opengl_backup_view() {
-    // save the framebuffer into a texture after rendering the 3D view(s)
-    // but before blitting the HUD overlay
+void opengl_end_frame() {
     SDL_GL_MakeCurrent(window, context);
 
-    glViewport(phys_offset_x, phys_offset_y, phys_width, phys_height);
-    bind_texture(viewBackupTexture);
-    glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, phys_offset_x, phys_offset_y, phys_width, phys_height);
-
-    glFlush();
+    // Done rendering to the frame buffer, reset back to normal
+    BindFrameBuffer(NULL);
     palette_dirty = FALSE;
+}
+
+void opengl_start_frame() {
+    SDL_GL_MakeCurrent(window, context);
+
+    // Start rendering to our frame buffer canvas
+    BindFrameBuffer(&backupBuffer);
+
+    // Setup the render width
+    int logical_width, logical_height;
+    SDL_RenderGetLogicalSize(renderer, &logical_width, &logical_height);
+
+    render_height = logical_height;
+    render_width = logical_width;
 }
 
 void opengl_swap_and_restore() {
@@ -309,7 +368,7 @@ void opengl_swap_and_restore() {
     glUniformMatrix4fv(textureShaderProgram.uniView, 1, false, IdentityMatrix);
     glUniformMatrix4fv(textureShaderProgram.uniProj, 1, false, IdentityMatrix);
 
-    bind_texture(viewBackupTexture);
+    bind_texture(backupBuffer.texture);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
@@ -356,15 +415,16 @@ void opengl_set_viewport(int x, int y, int width, int height) {
     render_height = height;
 
     SDL_GL_MakeCurrent(window, context);
-    int scaled_width = width * view_scale;
-    int scaled_height = height * view_scale;
-    int scaled_x = phys_offset_x + x * view_scale;
-    int scaled_y = phys_offset_y + phys_height - scaled_height - y * view_scale;
-    glViewport(scaled_x, scaled_y, scaled_width, scaled_height);
+
+    int lw, lh;
+    SDL_RenderGetLogicalSize(renderer, &lw, &lh);
+
+    int draw_y = lh - height - y;
+    glViewport(x, draw_y, width, height);
 
     // Make sure everything starts with a stencil of 0xFF
     glEnable(GL_SCISSOR_TEST);
-    glScissor(scaled_x, scaled_y, scaled_width, scaled_height);
+    glScissor(x, draw_y, width, height);
     glClearStencil(0xFF);
     glClear(GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
     glDisable(GL_SCISSOR_TEST);

--- a/src/MacSrc/OpenGL.h
+++ b/src/MacSrc/OpenGL.h
@@ -10,7 +10,7 @@ extern "C" {
 #ifdef USE_OPENGL
 
 int init_opengl();
-void opengl_cache_texture(int idx, int size, grs_bitmap *bm);
+void opengl_cache_wall_texture(int idx, int size, grs_bitmap *bm);
 void opengl_clear_texture_cache();
 
 bool use_opengl();
@@ -34,7 +34,7 @@ void opengl_set_stencil(int v);
 #else
 
 static int init_opengl() { return 0; }
-static void opengl_cache_texture(int idx, int size, grs_bitmap *bm) {}
+static void opengl_cache_wall_texture(int idx, int size, grs_bitmap *bm) {}
 static void opengl_clear_texture_cache() {};
 
 static bool use_opengl() { return false; }

--- a/src/MacSrc/OpenGL.h
+++ b/src/MacSrc/OpenGL.h
@@ -17,7 +17,6 @@ bool use_opengl();
 void toggle_opengl();
 void opengl_resize(int width, int height);
 bool should_opengl_swap();
-void opengl_backup_view();
 void opengl_swap_and_restore();
 void opengl_change_palette();
 
@@ -30,6 +29,8 @@ int opengl_draw_star(long c, int n_verts, g3s_phandle *p);
 void opengl_begin_stars();
 void opengl_end_stars();
 void opengl_set_stencil(int v);
+void opengl_start_frame();
+void opengl_end_frame();
 
 #else
 
@@ -41,7 +42,6 @@ static bool use_opengl() { return false; }
 static void toggle_opengl() {}
 static void opengl_resize(int width, int height) {}
 static bool should_opengl_swap() { return false; }
-static void opengl_backup_view() {}
 static void opengl_swap_and_restore() {}
 static void opengl_change_palette() {}
 
@@ -54,6 +54,8 @@ static int opengl_draw_star(long c, int n_verts, g3s_phandle *p) { return 0; }
 static void opengl_begin_stars() {}
 static void opengl_end_stars() {}
 static void opengl_set_stencil(int v) {}
+static void opengl_start_frame() {}
+static void opengl_end_frame() {}
 
 #endif
 


### PR DESCRIPTION
Rendering the 3d view to a texture decouples the rendering from the screen size, this makes the pixel sizes match the internal resolution again. It also opens the way to some fancy post processing effects.